### PR TITLE
Fix broken config file path

### DIFF
--- a/lib/invoice_creator/config_reader.rb
+++ b/lib/invoice_creator/config_reader.rb
@@ -7,7 +7,7 @@ module InvoiceCreator
     include Singleton
 
     def initialize
-      @yaml = YAML.load_file(File.expand_path('../../../config.yml', __FILE__))
+      @yaml = YAML.load_file(File.expand_path("../../../config.yml", __FILE__))
     end
 
     def settings

--- a/lib/invoice_creator/config_reader.rb
+++ b/lib/invoice_creator/config_reader.rb
@@ -7,7 +7,7 @@ module InvoiceCreator
     include Singleton
 
     def initialize
-      @yaml = YAML.load_file("config.yml")
+      @yaml = YAML.load_file(File.expand_path('../../../config.yml', __FILE__))
     end
 
     def settings


### PR DESCRIPTION
After transforming this codebase into a Ruby gem `config.yml` was no longer accessible using a relative path, given the user's CWD won't match the gem's folder.

Fixes https://github.com/nicholaspufal/invoice_creator/issues/9